### PR TITLE
Fix "no matching clause" exception due to sassc upgrade

### DIFF
--- a/src/leiningen/sassc.clj
+++ b/src/leiningen/sassc.clj
@@ -49,7 +49,7 @@
     (as-> (compile-node node) %
           (case (:exit %)
             0 (println (:out %))
-            1 (println (:err %))))))
+            (println (:err %))))))
 
 
 (defn- clean


### PR DESCRIPTION
Sassc version 3.4.8 uses more "specific" return codes (https://github.com/sass/sassc/pull/215/files#diff-87ef160ffcd46b07595bb62183c3389fR366). 

This causes a  "No matching clause" exception in `lein sassc`, because the `case` doesn't handle all the possible return values of sassc, for example `EX_DATAERR`, which is decimal `65`.

sassc will return `0` on success and non-zero on error, so this is what this PR does.